### PR TITLE
Handover Endpoint - Throw error when no agents are online

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "646b8e7d-f1e1-419e-9478-10d0f5bc74d9",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "requiredApiVersion": "^1.17.0",
     "iconFile": "icon.png",
     "author": {

--- a/enum/Logs.ts
+++ b/enum/Logs.ts
@@ -17,4 +17,5 @@ export enum Logs {
     CLOSE_CHAT_REQUEST_FAILED_ERROR = 'Error: Internal Server Error. Could not close the chat',
     HANDOVER_REQUEST_FAILED_ERROR = 'Error occurred while processing handover. Details',
     INVALID_DEPARTMENT_NAME_IN_BOTH_SETTING_AND_REQUEST = 'Error: Department Name cannot be empty. Please provide a department name either in App Setting or in the handover Request',
+    NO_AGENTS_ONLINE = 'Handover failed! No agents online',
 }

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -77,5 +77,7 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
         const offlineMessage: string = await getAppSettingValue(read, AppSetting.RasaServiceUnavailableMessage);
 
         await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_RasaServiceUnavailableMessage });
+
+        throw new Error(Logs.NO_AGENTS_ONLINE);
     }
 };


### PR DESCRIPTION
Fixes #20 

### Old behaviour:
If the handover fails and no agents were online, the endpoint would **not** throw any error and would return same **200** OK status code

### New Behaviour:
If the handover fails because no agents were online, the endpoint will throw an error 
Response status code: **500**
Response body: `{ "error": "Handover failed! No agents online" }`
